### PR TITLE
Bugfix: Controller binding not working if connected after app launch

### DIFF
--- a/PlayTools/Controls/PlayInput.swift
+++ b/PlayTools/Controls/PlayInput.swift
@@ -180,11 +180,10 @@ class PlayInput {
         let main = OperationQueue.main
 
         centre.addObserver(forName: NSNotification.Name.GCControllerDidConnect, object: nil, queue: main) { _ in
-            if !mode.visible {
-                self.setup()
-            }
             if EditorController.shared.editorMode {
                 self.toggleEditor(show: true)
+            } else {
+                self.setup()
             }
         }
         parseKeymap()


### PR DESCRIPTION
Fix a small regression: When connecting a controller after app launch we have to toggle the Keymap editor to get it saved before the binding work.  it's due to ControlMode.visibile being init at true so we don't call `setup` when the notification fires.